### PR TITLE
No 1.8V for sd cards

### DIFF
--- a/arch/arm/boot/dts/imx6sx-udoo-neo.dtsi
+++ b/arch/arm/boot/dts/imx6sx-udoo-neo.dtsi
@@ -353,6 +353,7 @@
 	pinctrl-0 = <&pinctrl_usdhc2>;
 	pinctrl-1 = <&pinctrl_usdhc2_100mhz>;
 	pinctrl-2 = <&pinctrl_usdhc2_200mhz>;
+	no-1-8-v;
 	bus-width = <4>;
 	cd-gpios = <&gpio6 2 GPIO_ACTIVE_LOW>;
 	keep-power-in-suspend;


### PR DESCRIPTION
Some sd cards can be switched to 1.8V. The udoo neo board does not support this.